### PR TITLE
Minor tweaks to interactive tours backend.

### DIFF
--- a/config/galaxy.ini.sample
+++ b/config/galaxy.ini.sample
@@ -273,12 +273,16 @@ paste.app_factory = galaxy.web.buildapp:app_factory
 # environment plugins.  By default none will be loaded.  Set to
 # config/plugins/interactive_environments to load Galaxy's stock plugins
 # (currently just IPython).  These will require Docker to be configured and
-# have security considerations, so proceed with caution.
+# have security considerations, so proceed with caution. The path is relative to the 
+# Galaxy root dir.  To use an absolute path begin the path with '/'.  This is a comma
+# separated list.
 #interactive_environment_plugins_directory =
 
 # Interactive tour directory: where to store interactive tour definition files.
 # Galaxy ships with several basic interface tours enabled, though a different
-# directory with custom tours can be specified here.
+# directory with custom tours can be specified here. The path is relative to the 
+# Galaxy root dir.  To use an absolute path begin the path with '/'.  This is a comma
+# separated list.
 #tour_config_dir = config/plugins/tours
 
 # Each job is given a unique empty directory as its current working directory.

--- a/lib/galaxy/tours/__init__.py
+++ b/lib/galaxy/tours/__init__.py
@@ -37,6 +37,25 @@ class ToursRegistry(object):
 
     def load_tour(self, tour_id):
         tour_path = os.path.join(self.tour_dir, tour_id + ".yaml")
+        if not os.path.exists(tour_path):
+            tour_path = os.path.join(self.tour_dir, tour_id + ".yml")
+        return self._load_tour_from_path(tour_path)
+
+    def load_tours(self):
+        self.tours = {}
+        for filename in os.listdir(self.tour_dir):
+            if filename.endswith('.yaml') or filename.endswith('.yml'):
+                self._load_tour_from_path(os.path.join(self.tour_dir, filename))
+        return self.tours_by_id_with_description()
+
+    def tour_contents(self, tour_id):
+        # Extra format translation could happen here (like the previous intro_to_tour)
+        # For now just return the loaded contents.
+        return self.tours.get(tour_id, None)
+
+    def _load_tour_from_path(self, tour_path):
+        filename = os.path.basename(tour_path)
+        tour_id = os.path.splitext(filename)[0]
         try:
             with open(tour_path) as handle:
                 conf = yaml.load(handle)
@@ -49,16 +68,3 @@ class ToursRegistry(object):
         except yaml.error.YAMLError:
             log.exception("Tour '%s' could not be loaded, error within file.  Please check your yaml syntax." % tour_id)
         return None
-
-    def load_tours(self):
-        self.tours = {}
-        for filename in os.listdir(self.tour_dir):
-            if filename.endswith('.yaml'):
-                tour_id = filename[:-5]
-                self.load_tour(tour_id)
-        return self.tours_by_id_with_description()
-
-    def tour_contents(self, tour_id):
-        # Extra format translation could happen here (like the previous intro_to_tour)
-        # For now just return the loaded contents.
-        return self.tours.get(tour_id, None)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1269,6 +1269,35 @@ def galaxy_directory():
     return os.path.abspath(galaxy_root_path)
 
 
+def config_directories_from_setting( directories_setting, galaxy_root=galaxy_root_path ):
+    """
+    Parse the ``directories_setting`` into a list of relative or absolute
+    filesystem paths that will be searched to discover plugins.
+
+    :type   galaxy_root:    string
+    :param  galaxy_root:    the root path of this galaxy installation
+    :type   directories_setting: string (default: None)
+    :param  directories_setting: the filesystem path (or paths)
+        to search for plugins. Can be CSV string of paths. Will be treated as
+        absolute if a path starts with '/', relative otherwise.
+    :rtype:                 list of strings
+    :returns:               list of filesystem paths
+    """
+    directories = []
+    if not directories_setting:
+        return directories
+
+    for directory in listify( directories_setting ):
+        directory = directory.strip()
+        if not directory.startswith( '/' ):
+            directory = os.path.join( galaxy_root, directory )
+        if not os.path.exists( directory ):
+            log.warn( 'directory not found: %s', directory )
+            continue
+        directories.append( directory )
+    return directories
+
+
 def parse_int(value, min_val=None, max_val=None, default=None, allow_none=False):
     try:
         value = int(value)

--- a/lib/galaxy/web/base/pluginframework.py
+++ b/lib/galaxy/web/base/pluginframework.py
@@ -64,38 +64,10 @@ class PluginManager( object ):
         self.skip_bad_plugins = skip_bad_plugins
         self.plugins = odict.odict()
 
-        self.directories = self.parse_directories_setting( app.config.root, directories_setting )
+        self.directories = util.config_directories_from_setting( directories_setting, app.config.root )
 
         self.load_configuration()
         self.load_plugins()
-
-    def parse_directories_setting( self, galaxy_root, directories_setting ):
-        """
-        Parse the ``directories_setting`` into a list of relative or absolute
-        filesystem paths that will be searched to discover plugins.
-
-        :type   galaxy_root:    string
-        :param  galaxy_root:    the root path of this galaxy installation
-        :type   directories_setting: string (default: None)
-        :param  directories_setting: the filesystem path (or paths)
-            to search for plugins. Can be CSV string of paths. Will be treated as
-            absolute if a path starts with '/', relative otherwise.
-        :rtype:                 list of strings
-        :returns:               list of filesystem paths
-        """
-        directories = []
-        if not directories_setting:
-            return directories
-
-        for directory in util.listify( directories_setting ):
-            directory = directory.strip()
-            if not directory.startswith( '/' ):
-                directory = os.path.join( galaxy_root, directory )
-            if not os.path.exists( directory ):
-                log.warn( '%s, directory not found: %s', self, directory )
-                continue
-            directories.append( directory )
-        return directories
 
     def load_configuration( self ):
         """

--- a/lib/galaxy/webapps/galaxy/api/tours.py
+++ b/lib/galaxy/webapps/galaxy/api/tours.py
@@ -21,7 +21,7 @@ class ToursController( BaseAPIController ):
         *GET /api/tours/
         Displays available tours
         """
-        return trans.app.tour_registry.tours_by_id_with_description()
+        return self.app.tour_registry.tours_by_id_with_description()
 
     @expose_api_anonymous_and_sessionless
     def show( self, trans, tour_id, **kwd ):
@@ -33,7 +33,7 @@ class ToursController( BaseAPIController ):
         :returns:   tour definition
         :rtype:     dictionary
         """
-        return trans.app.tour_registry.tour_contents(tour_id)
+        return self.app.tour_registry.tour_contents(tour_id)
 
     @expose_api
     @require_admin
@@ -44,4 +44,4 @@ class ToursController( BaseAPIController ):
         TODO: allow creation of new tours (which get written to the
         filesystem).
         """
-        return trans.app.tour_registry.load_tour(tour_id)
+        return self.app.tour_registry.load_tour(tour_id)

--- a/test/api/test_tours.py
+++ b/test/api/test_tours.py
@@ -1,0 +1,17 @@
+from base import api
+
+
+class TourApiTestCase( api.ApiTestCase ):
+
+    def test_index(self):
+        response = self._get( "tours" )
+        self._assert_status_code_is( response, 200 )
+        tours = response.json()
+        tour_keys = map(lambda t: t["id"], tours)
+        assert "core.history" in tour_keys
+
+    def test_show(self):
+        response = self._get( "tours/core.history" )
+        self._assert_status_code_is( response, 200 )
+        tour = response.json()
+        self._assert_has_keys(tour, "name", "description", "title_default", "steps")


### PR DESCRIPTION
 - Allow .yml extension (it is more popular for YAML files). 01fed4b
 - Stub API tests just to verify my refactoring. b9faf84 
 - Prefer ``self.app`` to ``trans.app`` in controllers - see https://github.com/galaxyproject/galaxy/pull/1392#commitcomment-15141262 for more information. b35a39b 
 - Allow multiple configuration directories, reuse logic from plugin framework to clarify and unify how directories are discovered. 7587809