### PR TITLE
Take auto height for labels of radio buttons

### DIFF
--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -804,7 +804,7 @@ $ui-margin-horizontal-large: 10px;
 .ui-radiobutton {
     width: 100%;
     label {
-        height: 23px;
+        height: auto;
         line-height: 1em;
     }
 


### PR DESCRIPTION
Fixes an issue with the labels of radio buttons. There is still a minor issue of bringing the text (or image) and radio button to the same horizontal level. 

![screenshot from 2018-04-03 18 56 26](https://user-images.githubusercontent.com/3022518/38263629-d8539a66-3770-11e8-8358-be848a6ac38c.png)
