### PR TITLE
Fix radio input horizontal alignment issue

### DIFF
--- a/client/galaxy/style/scss/galaxy_bootstrap/overrides.scss
+++ b/client/galaxy/style/scss/galaxy_bootstrap/overrides.scss
@@ -28,6 +28,7 @@ input[type="checkbox"],
 input[type="radio"] {
     margin-left: 0.5ex;
     margin-right: 0.5ex;
+    float: left;
 }
 
 // Modal -- wider by default, scroll like Trello

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -805,7 +805,7 @@ $ui-margin-horizontal-large: 10px;
     width: 100%;
     label {
         height: auto;
-        line-height: 1em;
+        line-height: 1.5em;
     }
 
     i {


### PR DESCRIPTION
Fixes the horizontal alignment issue for bootstrap radio buttons 

![align2](https://user-images.githubusercontent.com/3022518/38268743-2ace971a-377f-11e8-94b6-056820fc3c21.png)
![align1](https://user-images.githubusercontent.com/3022518/38268745-2af0068e-377f-11e8-8788-8ddf313549e3.png)
