### PR TITLE
Update the hashtags styling

### DIFF
--- a/client/galaxy/scripts/mvc/dataset/dataset-li.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li.js
@@ -326,7 +326,7 @@ var DatasetListItemView = _super.extend(
                 [
                     "<% _.each(_.sortBy(_.uniq(tags), function(x) { return x }), function(tag){ %>",
                     '<% if (tag.indexOf("name:") == 0){ %>',
-                    '<span class="badge badge-primary"><%- tag.slice(5) %></span>',
+                    '<span class="badge badge-primary badge-tags"><%- tag.slice(5) %></span>',
                     "<% } %>",
                     "<% }); %>"
                 ].join("")

--- a/client/galaxy/scripts/mvc/history/history-item-li.js
+++ b/client/galaxy/scripts/mvc/history/history-item-li.js
@@ -1,5 +1,5 @@
 function _templateNametag(tag) {
-    return `<span class="badge badge-primary">${_.escape(tag.slice(5))}</span>`;
+    return `<span class="badge badge-primary badge-tags">${_.escape(tag.slice(5))}</span>`;
 }
 
 function nametagTemplate(historyItem) {

--- a/client/galaxy/scripts/mvc/tag.js
+++ b/client/galaxy/scripts/mvc/tag.js
@@ -107,7 +107,7 @@ var TagsEditor = Backbone.View.extend(baseMVC.LoggableMixin)
             var renderedArray = [];
             _.each(tags, tag => {
                 tag = tag.indexOf("name:") == 0 ? tag.slice(5) : tag;
-                var renderString = `<span class="badge badge-primary">${tag}</span>`;
+                var renderString = `<span class="badge badge-primary badge-tags">${tag}</span>`;
                 renderedArray.push(renderString);
             });
             if (renderedArray.length === 0) {

--- a/client/galaxy/scripts/mvc/ui/ui-select-default.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-default.js
@@ -205,7 +205,7 @@ var View = Backbone.View.extend({
                         ${_.reduce(
                             filteredTags.slice(0, 5),
                             (memo, tag) => {
-                                return `${memo}&nbsp;<div class="badge badge-primary">${_.escape(tag)}</div>`;
+                                return `${memo}&nbsp;<div class="badge badge-primary badge-tags">${_.escape(tag)}</div>`;
                             },
                             ""
                         )}

--- a/client/galaxy/style/scss/galaxy_bootstrap/overrides.scss
+++ b/client/galaxy/style/scss/galaxy_bootstrap/overrides.scss
@@ -31,6 +31,13 @@ input[type="radio"] {
     float: left;
 }
 
+// Override badge's few default CSS
+.badge-tags {
+    background-color: #3189a3;
+    padding: .2em .6em .3em;
+    border-radius: 0.15rem;
+}
+
 // Modal -- wider by default, scroll like Trello
 
 .modal-dialog {


### PR DESCRIPTION
Updates the look and feel of hashtags as it was before by overriding the badge's default CSS.

![hashtags](https://user-images.githubusercontent.com/3022518/38270690-775611b2-3784-11e8-9aaa-af9b2ca337e4.png)
