### PR TITLE
Follow-ups from review of #23275: type the file source metadata channel

### DIFF
--- a/lib/galaxy/files/models.py
+++ b/lib/galaxy/files/models.py
@@ -16,6 +16,7 @@ from pydantic import (
     ConfigDict,
     Field,
 )
+from typing_extensions import TypedDict
 
 from galaxy.files.sources._defaults import (
     DEFAULT_SCHEME,
@@ -454,10 +455,19 @@ def resolve_file_source_template(
     return resolved_config_class(**expanded_dict)
 
 
-class FilesSourceRuntimeContext(Generic[TResolvedConfig]):
-    """Context for file source operations, providing user data and resolved configuration."""
+class RealizedSourceMetadata(TypedDict, total=False):
+    """What a file source learned while realizing a source - every key optional."""
 
-    def __init__(self, user_data: UserData, config: TResolvedConfig, metadata_out: Optional[dict] = None):
+    name: str
+
+
+class FilesSourceRuntimeContext(Generic[TResolvedConfig]):
+    """Context for file source operations: user data, resolved configuration, and an
+    optional channel for a source to report metadata back to the caller."""
+
+    def __init__(
+        self, user_data: UserData, config: TResolvedConfig, metadata_out: Optional[RealizedSourceMetadata] = None
+    ):
         self._user_data = user_data
         self._config = config
         self._metadata_out = metadata_out
@@ -473,7 +483,7 @@ class FilesSourceRuntimeContext(Generic[TResolvedConfig]):
         return self._config
 
     @property
-    def metadata_out(self) -> Optional[dict]:
+    def metadata_out(self) -> Optional[RealizedSourceMetadata]:
         """Caller-supplied dict a file source may populate with metadata about the realized source.
 
         This is how a file source reports back things it learns while realizing a

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -31,6 +31,7 @@ from galaxy.files.models import (
     FilesSourceProperties,
     FilesSourceRuntimeContext,
     FilesSourceTemplateContext,
+    RealizedSourceMetadata,
     resolve_file_source_template,
     TResolvedConfig,
     TTemplateConfig,
@@ -114,7 +115,7 @@ class SingleFileSource(metaclass=abc.ABCMeta):
         native_path: str,
         user_context: "OptionalUserContext" = None,
         opts: Optional[FilesSourceOptions] = None,
-        metadata_out: Optional[dict] = None,
+        metadata_out: Optional[RealizedSourceMetadata] = None,
     ):
         """Realize source path (relative to uri root) to local file system path.
 
@@ -129,7 +130,7 @@ class SingleFileSource(metaclass=abc.ABCMeta):
         :param metadata_out: An optional dict the file source may populate with metadata about the
             realized source that isn't derivable from the URI - currently only a ``name`` key
             reported by the DRS file source. Filesource specific, defaults to None
-        :type metadata_out: Optional[dict], optional
+        :type metadata_out: Optional[RealizedSourceMetadata], optional
         """
 
     @abc.abstractmethod
@@ -468,7 +469,7 @@ class BaseFilesSource(FilesSource, Generic[TTemplateConfig, TResolvedConfig]):
         self,
         opts: Optional[FilesSourceOptions] = None,
         user_context: "OptionalUserContext" = None,
-        metadata_out: Optional[dict] = None,
+        metadata_out: Optional[RealizedSourceMetadata] = None,
     ) -> FilesSourceRuntimeContext:
         """
         Get the runtime context for this file source, resolving the template configuration
@@ -603,7 +604,7 @@ class BaseFilesSource(FilesSource, Generic[TTemplateConfig, TResolvedConfig]):
         native_path: str,
         user_context: "OptionalUserContext" = None,
         opts: Optional[FilesSourceOptions] = None,
-        metadata_out: Optional[dict] = None,
+        metadata_out: Optional[RealizedSourceMetadata] = None,
     ):
         self._check_user_access(user_context)
         self._check_credentials_fresh()

--- a/lib/galaxy/files/sources/util.py
+++ b/lib/galaxy/files/sources/util.py
@@ -15,6 +15,7 @@ from galaxy.files import (
 from galaxy.files.models import (
     FilesSourceOptions,
     PartialFilesSourceProperties,
+    RealizedSourceMetadata,
 )
 from galaxy.files.uris import stream_url_to_file
 from galaxy.util import (
@@ -40,6 +41,9 @@ def sanitize_drs_name(name: Any) -> Optional[str]:
     A DRS server can put anything in this field, and it ends up both as a dataset name and
     as an input to downstream filename construction, so strip it down to a single path
     component with no control characters. Returns None if nothing usable is left.
+
+    Not :func:`galaxy.util.sanitize_for_filename` - that mangles legitimate Unicode and
+    substitutes a random id rather than reporting failure.
     """
     if not isinstance(name, str):
         return None
@@ -361,7 +365,7 @@ def fetch_drs_to_file(
     retry_options: Optional[RetryOptions] = None,
     headers: Optional[dict] = None,
     fetch_url_allowlist: Optional[list[IpAllowedListEntryT]] = None,
-    metadata_out: Optional[dict] = None,
+    metadata_out: Optional[RealizedSourceMetadata] = None,
 ):
     """Fetch contents of drs:// URI to a target path.
 

--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -15,7 +15,10 @@ from galaxy.files import (
     ConfiguredFileSources,
     NoMatchingFileSource,
 )
-from galaxy.files.models import FilesSourceOptions
+from galaxy.files.models import (
+    FilesSourceOptions,
+    RealizedSourceMetadata,
+)
 from galaxy.util import (
     stream_to_open_named_file,
     unicodify,
@@ -44,7 +47,7 @@ def stream_url_to_file(
     user_context=None,
     target_path: Optional[str] = None,
     file_source_opts: Optional[FilesSourceOptions] = None,
-    metadata_out: Optional[dict] = None,
+    metadata_out: Optional[RealizedSourceMetadata] = None,
 ) -> str:
     """Stream ``url`` to a local path and return that path.
 

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -518,7 +518,9 @@ def _directory_to_items(directory):
 
 def _has_src_to_name(item) -> Optional[str]:
     # Logic should broadly match logic of _has_src_to_path but not resolve the item
-    # into a path.
+    # into a path. Deliberately does not consult file source metadata the way
+    # _has_src_to_path does - a DRS name would require the very fetch deferral avoids,
+    # so deferred DRS datasets keep the URI basename.
     name = item.get("name")
     src = item.get("src")
     if src == "url":

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -22,6 +22,7 @@ from galaxy.datatypes.upload_util import (
 from galaxy.files.models import (
     FilesSourceOptions,
     PartialFilesSourceProperties,
+    RealizedSourceMetadata,
 )
 from galaxy.files.uris import (
     ensure_file_sources,
@@ -566,7 +567,7 @@ def _has_src_to_path(
 
         # Populated by file sources that can report a better name than the URI offers -
         # a DRS URI's last path segment is typically an opaque identifier.
-        source_metadata: dict[str, Any] = {}
+        source_metadata: RealizedSourceMetadata = {}
         try:
             path = stream_url_to_file(
                 url,

--- a/test/unit/files/test_drs.py
+++ b/test/unit/files/test_drs.py
@@ -13,6 +13,7 @@ from galaxy.files import (
     DictFileSourcesUserContext,
     ProvidesFileSourcesUserContext,
 )
+from galaxy.files.models import RealizedSourceMetadata
 from galaxy.files.sources.util import sanitize_drs_name
 from ._util import (
     assert_realizes_as,
@@ -166,7 +167,7 @@ def test_file_source_drs_http():
 
         # The DRS object's own name is reported back through metadata_out so callers can
         # name the dataset something better than the identifier in the URI.
-        metadata_out: dict[str, Any] = {}
+        metadata_out: RealizedSourceMetadata = {}
         with tempfile.NamedTemporaryFile(mode="r") as temp:
             file_source_pair.file_source.realize_to(
                 file_source_pair.path, temp.name, user_context=user_context, metadata_out=metadata_out
@@ -204,7 +205,7 @@ def test_file_source_drs_omits_unusable_name_from_metadata():
         user_context = user_context_fixture()
         file_sources = configured_file_sources(FILE_SOURCES_CONF)
         file_source_pair = file_sources.get_file_source_path(test_url)
-        metadata_out: dict[str, Any] = {}
+        metadata_out: RealizedSourceMetadata = {}
         with tempfile.NamedTemporaryFile(mode="r") as temp:
             file_source_pair.file_source.realize_to(
                 file_source_pair.path, temp.name, user_context=user_context, metadata_out=metadata_out


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of @jmchilton — they did not write this text personally.**

Two follow-ups from reviewing #23275, offered as a PR against your branch rather than pushed to it. Both are annotations and comments — no behavior change, and the tests pass at the same counts as before.

The design holds up. I went hunting for cross-contamination in `metadata_out` and there isn't any — `_get_runtime_context` builds a fresh context per call, `data_fetch` allocates the dict per item, no mutable defaults anywhere. Hanging it on the runtime context rather than `FilesSourceOptions` is right, and not just conveniently so: `FilesSourceOptions` is a `StrictModel`, pydantic copies on construct, and it's semantically an input model. The byte-based cap is correctly framed, and `sanitize_drs_name()` survived ~50 hostile inputs beyond the ones in your tests — no separator leaks, no `.`/`..` leaks, no invalid UTF-8 from a mid-character byte cut. The red commit is a real red commit: 7 failed at `a63e101d71`, 29 passed at `568f058ad4`.

### 1. Type the metadata channel

`metadata_out: Optional[dict]` leaves both `metadata_out["name"]` and `source_metadata.get("name")` as `Any`, so a typo in the key type-checks fine on either side and silently degrades to the URI basename — the bug this PR exists to fix, reintroduced as a silent one. `lib/galaxy/files/sources/` already reaches for `TypedDict` for loose JSON-ish payloads (`invenio.py`, `dataverse.py`, `elabftw.py`), so `RealizedSourceMetadata` follows that rather than starting a second convention.

Worth being precise about how much this actually buys, since I checked with mypy rather than assuming. The write side gets a direct `TypedDict "RealizedSourceMetadata" has no key "nmae"`. The read side does **not** — `.get()` with a non-key returns `object`, and it only errors downstream when that `object` reaches `_has_src_to_path`'s `tuple[str, str, bool]` return annotation. Caught either way, but by a different mechanism than you'd expect.

Also carries the `FilesSourceRuntimeContext` class docstring (it's an output channel now, and the class-level line is what people skim) and two lines on `sanitize_drs_name()` saying why it isn't `galaxy.util.sanitize_for_filename` — that's the function the next reviewer will ask about, and the answer is worth writing down once: it maps everything outside `[A-Za-z0-9_.]` to `_`, so `ünïcödé.txt` becomes `________.txt`; it has no length bound; and on rejection it substitutes a random id where you need `None` to fall back to the URI basename.

### 2. `_has_src_to_name`'s comment

"Logic should broadly match logic of `_has_src_to_path`" stopped being true for `drs://`. The divergence is correct — resolving a DRS name needs the very fetch deferral exists to avoid — but the comment as written sends the next reader hunting a bug that isn't there.

### Not patched — flagging instead

- **The deferred divergence never heals.** `model/deferred.py:265` calls `stream_url_to_file()` with no `metadata_out`, so a deferred `drs://` keeps the UUID *permanently*, not just until materialization. I agree it's out of scope here, but `deferred.py:265` is where it'd be cheap later — probably worth an issue against `dev` rather than silence.
- **The `handle_upload` bound is correct by accident of dead code.** `os.path.splitext(name)[1]` appears twice in `upload_util.py`; you mention the unsniffable-binary one. The other feeds `uploaded_file_ext`, which is harmless only because `handle_uploaded_dataset_file_internal()` accepts it and never reads it. Worth a sentence so whoever eventually wires it up doesn't silently widen a remote server's say over datatype selection. `is_extension_unsniffable_binary()` does hold up otherwise — it requires a `Binary` subclass *without* a sniffer, so `bam` isn't in the reachable set, and the parity argument with plain `https://` uploads is real.
- **Pre-existing, adjacent, not yours:** `_get_runtime_context()` — the function this PR extends — does `self.template_config = self.template_config.model_copy(update=extra_props)` from a per-call path, mutating the shared long-lived file source instance, so `opts.extra_props` from one fetch persists into every later fetch through that source. `metadata_out` deliberately avoids exactly this bug class, which is why I found no contamination. Deserves its own issue against `dev`.
- `url.split("/")[-1]` is now three copies in `data_fetch.py` (`:526`, `:557`, `:589`). A `_name_from_url()` helper would cover all three, but I didn't want to widen the diff on a release branch.

### Testing

`test/unit/files/test_drs.py` and `test/unit/app/tools/test_data_fetch.py`: 64 passed, identical to before these commits. black / ruff / flake8 clean via pre-commit; isort run separately, since it isn't a pre-commit hook here.

The two commits are kept separate so you can drop either one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
